### PR TITLE
Fix escaping in code generation, propagate load errors, clean up refs

### DIFF
--- a/src/intersystems_pyprod/_parser.py
+++ b/src/intersystems_pyprod/_parser.py
@@ -149,6 +149,7 @@ def load_to_iris(cls_string, cls_name):
             "No module named 'iris': You need to set the PYTHONPATH environment variable to point to /iris_install_dir/lib/python"
         )
         print(e)
+        raise SystemExit(1)
 
 
 # _______________________________________________________________________________________________________________________ load_to_iris #
@@ -514,10 +515,11 @@ def extract_props_and_settings(node: ast.ClassDef, real_path, loaded_module):
         datatype = DATATYPE_MAP.get(dtype, '%VarString')
         line = f"Property {prop_name} As {datatype}"
         if default is not None:
+            sanitized_default = " ".join(str(default).splitlines())
             if datatype == "%VarString":
-                line += f' [InitialExpression = "{default}"]'
+                line += f' [InitialExpression = "{sanitized_default}"]'
             else:
-                line += f" [InitialExpression = {default}]"
+                line += f" [InitialExpression = {sanitized_default}]"
 
         line += "; \n"
         props.append(line)

--- a/src/intersystems_pyprod/_production_connector.py
+++ b/src/intersystems_pyprod/_production_connector.py
@@ -209,15 +209,15 @@ class AdapterNamesToPascal:
             # Wrap method calls so args pass through unchanged
             def method(*args, **kwargs):
                 arguments = (args, kwargs)
-                
-                response = iris.ref()
-                # arguments can be passed in as a single python object as the boundary between 
-                # BO and out adapter can handle %SYS.Python objects..
-                status = attr(arguments,response)
 
-                response_value = response.value
-                response.value = None
-                del response
+                response = iris.ref()
+                try:
+                    status = attr(arguments,response)
+
+                    response_value = response.value
+                finally:
+                    response.value = None
+                    del response
 
                 if isinstance(response_value, tuple):
                     return (status, *response_value)
@@ -368,21 +368,23 @@ class BusinessService(BaseClass):
     def SendRequestSync(self, target_dispatch_name, request, timeout=-1, description=""):
         response = iris.ref()
         send_sync_handling = iris.ref()
-        status = self.iris_host_object.SendRequestSync(
-            target_dispatch_name,
-            self.request_to_send(request),
-            response,
-            timeout,
-            description,
-            send_sync_handling,
-        )
+        try:
+            status = self.iris_host_object.SendRequestSync(
+                target_dispatch_name,
+                self.request_to_send(request),
+                response,
+                timeout,
+                description,
+                send_sync_handling,
+            )
 
-        response_value = response.value
-        response.value = None
-        send_sync_handling_value = send_sync_handling.value
-        send_sync_handling.value = None
-        del response
-        del send_sync_handling
+            response_value = response.value
+            send_sync_handling_value = send_sync_handling.value
+        finally:
+            response.value = None
+            send_sync_handling.value = None
+            del response
+            del send_sync_handling
 
         if send_sync_handling_value is not None:
             if response_value is not None:
@@ -398,14 +400,14 @@ class BusinessService(BaseClass):
                 return status
 
         return status
-    
+
     def send_request_sync(self, target_dispatch_name, request, timeout=-1, description=""):
         return self.SendRequestSync(target_dispatch_name, request, timeout, description)
 
     def SendRequestAsync(self, target_dispatch_name, request, description=""):
         status = self.iris_host_object.SendRequestAsync(target_dispatch_name, self.request_to_send(request), description)
         return status
-    
+
     def send_request_async(self, target_dispatch_name, request, description=""):
         return self.SendRequestAsync(target_dispatch_name, request, description)
 
@@ -472,17 +474,19 @@ class BusinessProcess(BaseClass):
 
     def SendRequestSync(self, target_dispatch_name, request, timeout=-1, description=""):
         response = iris.ref()
-        status = self.iris_host_object.SendRequestSync(target_dispatch_name,self.request_to_send(request),response,timeout,description)
+        try:
+            status = self.iris_host_object.SendRequestSync(target_dispatch_name,self.request_to_send(request),response,timeout,description)
 
-        response_value = response.value
-        response.value = None
-        del response
+            response_value = response.value
+        finally:
+            response.value = None
+            del response
 
         if response_value is not None:
             return status, self._createmessage(message_object=response_value)
         else:
             return status
-        
+
     def send_request_sync(self, target_dispatch_name, request, timeout=-1, description=""):
         return self.SendRequestSync( target_dispatch_name, request, timeout, description)
 
@@ -529,30 +533,32 @@ class BusinessOperation(BaseClass):
 
     def SendRequestSync(self, target_dispatch_name, request, timeout=-1, description=""):
         response = iris.ref()
-        status = self.iris_host_object.SendRequestSync(
-            target_dispatch_name,
-            self.request_to_send(request),
-            response,
-            timeout,
-            description,
-        )
+        try:
+            status = self.iris_host_object.SendRequestSync(
+                target_dispatch_name,
+                self.request_to_send(request),
+                response,
+                timeout,
+                description,
+            )
 
-        response_value = response.value
-        response.value = None
-        del response
+            response_value = response.value
+        finally:
+            response.value = None
+            del response
 
         if response_value is not None:
             return status, self._createmessage(message_object=response_value)
         else:
             return status
-        
+
     def send_request_sync(self, target_dispatch_name, request, timeout=-1, description=""):
         return self.SendRequestSync(target_dispatch_name, request, timeout, description)
 
     def SendRequestAsync(self, target_dispatch_name, request, description=""):
         status = self.iris_host_object.SendRequestAsync(target_dispatch_name, self.request_to_send(request), description)
         return status
-    
+
     def send_request_async(self, target_dispatch_name, request, description=""):
         return self.SendRequestAsync(target_dispatch_name, request, description)
 
@@ -573,21 +579,22 @@ class InboundAdapter(BaseClass):
             raise NotImplementedError("Subclass must implement OnTask or on_task")
     
     def BusinessHost_ProcessInput(self, input, in_hint=""):
-        
+
         output = iris.ref()
         output.value = ""
         temp_hint = in_hint
         hint = iris.ref()
         hint.value = temp_hint
-        status = self.iris_host_object.BusinessHost.ProcessInput(input, output, hint)
+        try:
+            status = self.iris_host_object.BusinessHost.ProcessInput(input, output, hint)
 
-        output_value = output.value
-        output.value = None
-        del output
-
-        hint_value = hint.value
-        hint.value = None
-        del hint
+            output_value = output.value
+            hint_value = hint.value
+        finally:
+            output.value = None
+            del output
+            hint.value = None
+            del hint
 
         if in_hint != "":
             if (output_value is not None) and (output_value != ""):

--- a/src/intersystems_pyprod/_production_definition.py
+++ b/src/intersystems_pyprod/_production_definition.py
@@ -3,6 +3,16 @@ from typing import Optional
 
 from ._method_stubs import STUBS
 
+
+def _escape_xml(value: str) -> str:
+    s = str(value)
+    s = s.replace("&", "&amp;")
+    s = s.replace("<", "&lt;")
+    s = s.replace(">", "&gt;")
+    s = s.replace('"', "&quot;")
+    return s
+
+
 def _snake_to_pascal(name: str) -> str:
     # Check if the string is in snake_case
     if "_" in name and (name.lower() == name or name.upper() == name):
@@ -181,7 +191,7 @@ class ServiceItem(_HostItem):
     """ 
              
 class ProcessItem(_HostItem):
-    """Declares a business service item in a Production definition.
+    """Declares a business process item in a Production definition.
 
     Parameters
     ----------
@@ -248,7 +258,7 @@ class ProcessItem(_HostItem):
         Overriding by a matching System Default Setting will occur even if this value is defined in the production definition.
     """ 
 class OperationItem(_HostItem):
-    """Declares a business service item in a Production definition.
+    """Declares a business operation item in a Production definition.
 
     Parameters
     ----------
@@ -344,7 +354,7 @@ def _create_item_target_settings(target, host_obj):
 
     item_target_settings = []
     for name, value in getattr(host_obj, f"{target}_settings").items():
-        setting = f"""       <Setting Target="{target.capitalize()}" Name="{_snake_to_pascal(name)}">{value}</Setting>"""
+        setting = f"""       <Setting Target="{target.capitalize()}" Name="{_snake_to_pascal(name)}">{_escape_xml(value)}</Setting>"""
         item_target_settings.append(setting)
   
     return "\n"+"\n".join(item_target_settings) if item_target_settings else ""
@@ -356,7 +366,7 @@ def _create_production_item(cls_obj):
     
     def create_item(item):
         complete_string = f"""
-    <Item Name="{item.name}" Category="{item.category}" ClassName="{item.class_name}" PoolSize="{item.pool_size}" Enabled="{item.enabled}" Foreground="{item.foreground}" Comment="{item.comment}" LogTraceEvents="{item.log_trace_events}" Schedule="{item.schedule}">{_create_item_target_settings("host",item)}{_create_item_target_settings("adapter",item)}
+    <Item Name="{_escape_xml(item.name)}" Category="{_escape_xml(item.category)}" ClassName="{_escape_xml(item.class_name)}" PoolSize="{item.pool_size}" Enabled="{item.enabled}" Foreground="{item.foreground}" Comment="{_escape_xml(item.comment)}" LogTraceEvents="{item.log_trace_events}" Schedule="{_escape_xml(item.schedule)}">{_create_item_target_settings("host",item)}{_create_item_target_settings("adapter",item)}
     </Item>
 """
         return complete_string


### PR DESCRIPTION
## Summary

- Fix XML special characters (`&<>"`) in production definition settings producing invalid XML
- Fix multi-line string defaults in IRISProperty producing invalid ObjectScript syntax
- Make `load_to_iris` exit non-zero on failure so CI/CD can detect broken deployments
- Add try/finally around `iris.ref()` usage to prevent reference leaks on exception
- Fix copy-paste docstring errors in ProcessItem/OperationItem

## Related Issues

- Fixes #6
- Fixes #13
- Fixes #14 

## What changed

**`_production_definition.py`**
- Added `_escape_xml()` helper that escapes `&`, `<`, `>`, `"` before interpolation into XML
- Applied escaping to setting values and item attributes (name, category, class_name, comment, schedule)
- Fixed ProcessItem docstring: "business service" → "business process"
- Fixed OperationItem docstring: "business service" → "business operation"

**`_parser.py`**
- Multi-line `IRISProperty` defaults are collapsed to single-line before emitting `InitialExpression`
- `load_to_iris` now raises `SystemExit(1)` after printing the error diagnostic

**`_production_connector.py`**
- Wrapped `iris.ref()` patterns in try/finally across `BusinessService.SendRequestSync`, `BusinessProcess.SendRequestSync`, `BusinessOperation.SendRequestSync`, `InboundAdapter.BusinessHost_ProcessInput`, and the `AdapterNamesToPascal` method wrapper

All fixes are tightly scoped, use only the Python standard library, and preserve the existing Production architecture.